### PR TITLE
Fix use of \@author

### DIFF
--- a/chapters/chap_0.tex
+++ b/chapters/chap_0.tex
@@ -37,9 +37,11 @@ Dies gilt sinngemäß auch für verwendete Zeichnungen, Skizzen, bildliche Darst
 Ich versichere auch, dass die von mir eingereichte schriftliche Version mit der digitalen Version übereinstimmt.
 Ich erkläre mich damit einverstanden, dass die digitale Version dieser Arbeit zwecks Plagiatsprüfung verwendet wird.\@}
 
+\makeatletter
 \vspace{2cm}
 \rule{4cm}{0.1pt} \hfill \rule{7cm}{0.1pt} \\
 \hspace*{1.5cm} \textsc{Date} \hspace*{7cm} \textsc{\@author}
+\makeatother
 
 \cleardoublepage
 
@@ -50,9 +52,11 @@ Lehrstuhl NDS dauerhaft in elektronischer und gedruckter Form aufbewahrt
 wird und dass die Ergebnisse aus dieser Arbeit unter Einhaltung guter
 wissenschaftlicher Praxis in der Forschung weiter verwendet werden dürfen.\@}
 
+\makeatletter
 \vspace{2cm}
 \rule{4cm}{0.1pt} \hfill \rule{7cm}{0.1pt} \\
 \hspace*{1.5cm} \textsc{Date} \hspace*{7cm} \textsc{\@author}
+\makeatother
 
 \cleardoublepage
 


### PR DESCRIPTION
The use of the \@author command requires _at_ to be treated as a letter. As this was obviously not the case in this document, I added the corresponding \makeatletter and \makeatother commands where necessary.