### PR TITLE
replace obsolete scrpage2 with scrlayer-scrpage

### DIFF
--- a/misc/preamble.tex
+++ b/misc/preamble.tex
@@ -95,7 +95,7 @@
 \usepackage[ruled, vlined, linesnumbered,algochapter,algo2e]{algorithm2e}
 
 % Format page foot and header
-\usepackage{scrpage2}
+\usepackage{scrlayer-scrpage}
 \clearscrheadings
 \clearscrheadfoot
 \automark[section]{chapter}


### PR DESCRIPTION
scrpage2 is no longer part of Tex Live or MikTeX.
scrlayer-scrpage seems to be a drop-in replacement.

https://tex.stackexchange.com/questions/541766/latex-error-file-scrpage2-sty-not-found