### PR TITLE
Fix ltex-ls java error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:debian-11
 
 # [Optional] Uncomment this section to install additional packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends biber curl git git-lfs latexmk lmodern locales make neovim pandoc procps python3-pip texlive texlive-bibtex-extra texlive-extra-utils texlive-fonts-extra texlive-lang-german texlive-latex-extra texlive-science texlive-xetex && \
+    && apt-get -y install --no-install-recommends openjdk-17-jdk biber curl git git-lfs latexmk lmodern locales make neovim pandoc procps python3-pip texlive texlive-bibtex-extra texlive-extra-utils texlive-fonts-extra texlive-lang-german texlive-latex-extra texlive-science texlive-xetex && \
     pip3 install Pygments && \
     rm -rf /var/lib/apt/lists/*
+
+RUN sudo mv /usr/lib/jvm/java-17-openjdk-* /usr/lib/jvm/java-17-openjdk

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
             "Protocol"
           ]
         },
+        "ltex.java.path": "/usr/lib/jvm/java-17-openjdk",
         "latex-workshop.latex.tools": [
           {
             "name": "latexmk",


### PR DESCRIPTION
When opening the project in a vscode devcontainer the ltex language server errors

The solution is to install openjdk in the docker image and then set the ltex.java.path option in the devcontainer config.